### PR TITLE
Use /usr/bin/env python3 rather than hard-coded /usr/bin/python3.

### DIFF
--- a/gabctk.py
+++ b/gabctk.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """GabcTk


### PR DESCRIPTION
Ceci me paraît plus compatible avec systèmes comme MacPorts, qui mettent python3 dans /opt/local.

Merci!